### PR TITLE
fix: invalid dsn format during decode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 .DS_Store
+
+.idea

--- a/driver/ssh/config_test.go
+++ b/driver/ssh/config_test.go
@@ -22,15 +22,39 @@ func TestSSHConfigEncodeWithDSN(t *testing.T) {
 }
 
 func TestSSHConfigDecodeWithDSN(t *testing.T) {
-	encodedDSN := "postgres://ssh_user@ssh_host:22/user:password@host:5439/db?query1=val1&query2=val2&ssh_private_key=myprivate_key%26val"
-	config := &Config{}
+	t.Run("valid dsn", func(t *testing.T) {
+		encodedDSN := "postgres://ssh_user@ssh_host:22/user:password@host:5439/db?query1=val1&query2=val2&ssh_private_key=myprivate_key%26val"
+		config := &Config{}
 
-	whDSN, err := config.DecodeFromDSN(encodedDSN)
-	require.Nil(t, err)
-	require.Equal(t, "postgres://user:password@host:5439/db?query1=val1&query2=val2", whDSN)
+		whDSN, err := config.DecodeFromDSN(encodedDSN)
+		require.Nil(t, err)
+		require.Equal(t, "postgres://user:password@host:5439/db?query1=val1&query2=val2", whDSN)
 
-	require.Equal(t, config.Host, "ssh_host")
-	require.Equal(t, config.Port, 22)
-	require.Equal(t, config.User, "ssh_user")
-	require.Equal(t, string(config.PrivateKey), "myprivate_key&val")
+		require.Equal(t, config.Host, "ssh_host")
+		require.Equal(t, config.Port, 22)
+		require.Equal(t, config.User, "ssh_user")
+		require.Equal(t, string(config.PrivateKey), "myprivate_key&val")
+	})
+	t.Run("invalid dsn", func(t *testing.T) {
+		testCases := []struct {
+			name       string
+			encodedDSN string
+		}{
+			{
+				name:       "splitting by :// gives unexpected results",
+				encodedDSN: "postgres://ssh_user@http://ssh_host/:22/user:password@host:5439/db?query1=val1&query2=val2&ssh_private_key=myprivate_key%26val",
+			},
+			{
+				name:       "missing / after ssh_port",
+				encodedDSN: "postgres://ssh_user@ssh_host:22",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := (&Config{}).DecodeFromDSN(tc.encodedDSN)
+				require.Error(t, err)
+			})
+		}
+	})
 }

--- a/driver/ssh/driver.go
+++ b/driver/ssh/driver.go
@@ -139,10 +139,6 @@ func replaceHostPort(baseurl, newHost, newPort string) string {
 	return parsed.String()
 }
 
-func CombineError(base, err error) (updated error) {
-	return fmt.Errorf("%v:%v", base, err)
-}
-
 type ErrorCombiner []error
 
 func (ec *ErrorCombiner) Combine(err error) {

--- a/tunnel/ssh.go
+++ b/tunnel/ssh.go
@@ -37,7 +37,7 @@ type SSH struct {
 func ListenAndForward(config *SSHConfig) (*SSH, error) {
 	singer, err := ssh.ParsePrivateKey(config.PrivateKey)
 	if err != nil {
-		return nil, fmt.Errorf("parsing private key: %s", err.Error())
+		return nil, fmt.Errorf("parsing private key: %w", err)
 	}
 
 	endpoint := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))


### PR DESCRIPTION
# Description

- In the case of idx as -1, we are trying to access err which is nil.
- Avoid adding DSNs in error, since these DSNs contain passwords that will be stored in our system.
- Added sufficient checks during encoding as well.

## Linear Ticket

resolves PIPE-679

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
