### PR TITLE
chore(ci): downgrade release-please-action to v3.7.13 (SEC-367)

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
-      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
+      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3.7.13
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-title-pattern: "chore: release ${version}"


### PR DESCRIPTION
release-please v4 ignores the v3-only inputs (package-name, default-branch, changelog-types, bump-minor-pre-major, pull-request-title-pattern), so chore commits were never considered releasable and no release PR has been opened since v0.1.7. Repin to the latest v3 release, which honors these inputs.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🔒 Scanned for secrets using gitleaks 8.28.0